### PR TITLE
HFP-3249 Make word-wrap use break-word for content panel

### DIFF
--- a/h5p-accordion.css
+++ b/h5p-accordion.css
@@ -41,6 +41,7 @@
 .h5p-accordion .h5p-panel-content {
   display: none;
   padding: 0 1em;
+  word-break: break-word;
 }
 .h5p-accordion .h5p-panel-content p {
   margin-top: 0;


### PR DESCRIPTION
As reported in https://h5p.org/node/1139616 and documented in https://h5ptechnology.atlassian.net/browse/HFP-3249 long words or links in particular get cut off when overflowing the content panel. Fixed by setting `word-wrap: break-word` - but not working for IE11 (let it go ...). The rather better way would be to set `overflow-wrap: anywhere` - but that does neither work on IE11 nor on Safari.